### PR TITLE
Don't trigger error when using the word 'constructor' in a diffString()

### DIFF
--- a/jsdiff.js
+++ b/jsdiff.js
@@ -70,8 +70,8 @@ function diffString( o, n ) {
 }
 
 function diff( o, n ) {
-  var ns = new Object();
-  var os = new Object();
+  var ns = Object.create(null);
+  var os = Object.create(null);
 
   for ( var i = 0; i < n.length; i++ ) {
     if ( ns[ n[i] ] == null )


### PR DESCRIPTION
Hi clubhouse.io team,

We bumped into this error today in our own project, and we noticed by looking around that you have the same tricky bug waiting to happen.

```javascript
diffString('I met this builder today', 'I met this construction worker today')
> "I  met  this <del>builder </del><ins>construction </ins><ins>worker </ins> today"
```

👍 

```javascript
diffString('I met this builder today', 'I met this constructor today')
> Uncaught TypeError: Cannot read property 'push' of undefined
```

👎 

My guess is that you will certainly bump into the same painful error someday, when one of your clients will use the word "constructor".

The fix was found here: https://stackoverflow.com/questions/21320256/is-there-a-way-to-make-constructor-a-valid-key-in-a-js-object

Complimentary gift from the Translation.io team 😄 